### PR TITLE
Remove edge case

### DIFF
--- a/db.json
+++ b/db.json
@@ -83,17 +83,17 @@
     },
     {
       "amount": 1230.085,
-      "date": "2020-01-02",
+      "date": "2020-08-01",
       "payment_plan_id": 3
     },
     {
       "amount": 1230.085,
-      "date": "2020-01-15",
+      "date": "2020-08-08",
       "payment_plan_id": 3
     },
     {
       "amount": 1230.085,
-      "date": "2020-02-14",
+      "date": "2020-08-15",
       "payment_plan_id": 3
     }
   ]


### PR DESCRIPTION
Payments were made before payment plans were created. This is a silly edge case and is just confusing.